### PR TITLE
Add ~gysohn logo and dark mode toggle setup in Header

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,4 +1,4 @@
-import { NavLink } from 'react-router-dom';
+import { Link, NavLink } from 'react-router-dom';
 import '../styles/Header.css';
 
 const navItems = [
@@ -10,6 +10,9 @@ const navItems = [
 function Header() {
   return (
     <header className="site-header">
+      <div className="header-left">
+        <Link to="/" className="logo">~GySohn</Link>
+      </div>
       <nav className="navbar-box">
         {navItems.map(({ name, to }) => (
           <NavLink
@@ -22,10 +25,12 @@ function Header() {
             {name}
           </NavLink>
         ))}
+        <button className="dark-toggle" aria-label="Toggle dark mode">
+          🌓
+        </button>
       </nav>
     </header>
   );
 }
-
 
 export default Header;

--- a/src/styles/Header.css
+++ b/src/styles/Header.css
@@ -1,9 +1,37 @@
 .site-header {
   display: flex;
-  justify-content: flex-end;
+  justify-content: space-between;
+  align-items: center;
   padding: var(--space-sm) var(--space-lg);
 }
 
+/* Logo / Brand */
+.header-left .logo {
+  font-size: 1.25rem;
+  font-weight: bold;
+  color: var(--text-secondary);
+  text-decoration: none;
+  font-family: var(--font-heading);
+  transition: color 0.2s ease-in-out;
+}
+
+.logo:hover {
+  color: var(--accent-button);
+}
+
+/* Dark mode toggle button */
+.dark-toggle {
+  background: none;
+  border: none;
+  font-size: 1.2rem;
+  cursor: pointer;
+  color: var(--text-secondary);
+  transition: color 0.2s ease-in-out;
+}
+
+.dark-toggle:hover {
+  color: var(--accent-button);
+}
 .navbar-box {
   display: flex;
   gap: var(--space-md);


### PR DESCRIPTION
This update introduces a simple text-based logo ~gysohn to the top left of the site header, which also links back to the homepage. A dark mode toggle button (🌓) has been added to the right-hand side of the navbar as a placeholder — functionality will be added in a future update. Styling is responsive and matches the existing CSS variable system.